### PR TITLE
chore: change required PHP versions and upgrade PestPHP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
+          - 8.5
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
           - 8.0
           - 8.1
           - 8.2
+          - 8.3
+          - 8.4
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
+          - 8.5
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
           - 8.2
           - 8.3
           - 8.4
-          - 8.5
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 8.0
-          - 8.1
           - 8.2
           - 8.3
           - 8.4

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Fires postPersist / postUpdate / postRemove events AFTER the transaction has completed.",
     "type": "library",
     "require": {
-        "php": ">=8.0",
+        "php": ">=8.2",
         "doctrine/orm": "~2.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "doctrine/orm": "~2.0"
     },
     "require-dev": {
-        "pestphp/pest": "^1.22",
+        "pestphp/pest": "^2.36|^3.8|^4.4",
         "phpstan/phpstan": "^1.8",
         "squizlabs/php_codesniffer": "^3.7",
         "symfony/cache": "~5.4|~6.2",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,8 +6,5 @@ parameters:
         - tests
     ignoreErrors:
         -
-            message: '#Call to an undefined method Pest\\Expectation\|Pest\\Support\\Extendable#'
-            path: tests/*
-        -
             message: '#Undefined variable: \$this#'
             path: tests/*

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,5 +6,8 @@ parameters:
         - tests
     ignoreErrors:
         -
+            message: '#Call to an undefined method PHPUnit\\Framework\\TestCase::getEntityManager\(\)#'
+            path: tests/*
+        -
             message: '#Undefined variable: \$this#'
             path: tests/*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,12 +10,12 @@
     </php>
     <testsuites>
         <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
+            <directory>./tests</directory>
         </testsuite>
     </testsuites>
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
-            <directory suffix=".php">./src</directory>
+            <directory>./src</directory>
         </include>
-    </coverage>
+    </source>
 </phpunit>


### PR DESCRIPTION
Add:
- PHP `8.3`
- PHP `8.4`
- PHP `8.5`

Remove:
- PHP `8.0`
- PHP `8.1`

Keep:
- PHP `8.2`

It also upgrades the PestPHP versions to remove v1 and add v2, v3 and v4 because of this error with PestPHP v1 and PHP `8.4` and `8.5`:
```
  Pest\PendingObjects\TestCall::__construct(): Implicitly marking parameter $description as nullable is deprecated, the explicit nullable type must be used instead

  at vendor/pestphp/pest/src/PendingObjects/TestCall.php:52
     48▕
     49▕     /**
     50▕      * Creates a new instance of a pending test call.
     51▕      */
  ➜  52▕     public function __construct(TestSuite $testSuite, string $filename, string $description = null, Closure $closure = null)
     53▕     {
     54▕         $this->testCaseFactory = new TestCaseFactory($filename, $description, $closure);
     55▕         $this->testSuite       = $testSuite;
     56▕         $this->descriptionLess = $description === null;

      +5 vendor frames
  6   tests/SafeEventsDispatcherTest.php:20
```

It closes #8.