### PR TITLE
chore: add compatibility with Doctrine ORM v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=8.2",
-        "doctrine/orm": "~2.0|~3.0"
+        "doctrine/orm": "~2.20|~3.6"
     },
     "require-dev": {
         "pestphp/pest": "^2.36|^3.8|^4.4",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "require": {
         "php": ">=8.2",
-        "doctrine/orm": "~2.0"
+        "doctrine/orm": "~2.0|~3.0"
     },
     "require-dev": {
         "pestphp/pest": "^2.36|^3.8|^4.4",

--- a/tests/EntityManagerAwareTestCase.php
+++ b/tests/EntityManagerAwareTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Bentools\DoctrineSafeEvents\Tests;
 
+use Doctrine\DBAL\DriverManager;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\ORMSetup;
@@ -20,10 +21,12 @@ trait EntityManagerAwareTestCase
             isDevMode: true,
         );
 
-        $this->entityManager = EntityManager::create(
-            ['driver' => 'pdo_sqlite', 'memory' => true],
-            $config,
+        $connection = DriverManager::getConnection(
+            params: ['driver' => 'pdo_sqlite', 'memory' => true],
+            config: $config,
         );
+
+        $this->entityManager = new EntityManager($connection, $config);
 
         $schemaTool = new SchemaTool($this->entityManager);
         $schemaTool->createSchema(


### PR DESCRIPTION
This PR adds the compatibility to Doctrine ORM v3 in addition to v2.

We change the way to create the entity manager because of: https://github.com/doctrine/orm/commit/f3f453286fa9926db3b489d6afabb0a0add7efe2.