### PR TITLE
chore: fix collision on test setup and minimum of PHP 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - 7.4
           - 8.0
           - 8.1
           - 8.2

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,6 @@
         "doctrine/orm": "~2.0"
     },
     "require-dev": {
-        "doctrine/annotations": "~1.0",
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^1.8",
         "squizlabs/php_codesniffer": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     },
     "require-dev": {
         "doctrine/annotations": "~1.0",
-        "matthiasnoback/doctrine-orm-test-service-provider": "^3.0",
         "pestphp/pest": "^1.22",
         "phpstan/phpstan": "^1.8",
         "squizlabs/php_codesniffer": "^3.7",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Fires postPersist / postUpdate / postRemove events AFTER the transaction has completed.",
     "type": "library",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "doctrine/orm": "~2.0"
     },
     "require-dev": {

--- a/tests/Entity/User.php
+++ b/tests/Entity/User.php
@@ -9,21 +9,15 @@ use Doctrine\ORM\Mapping\Entity;
 use Doctrine\ORM\Mapping\GeneratedValue;
 use Doctrine\ORM\Mapping\Id;
 
-/**
- * @Entity
- */
+#[Entity]
 class User
 {
-    /**
-     * @Id
-     * @Column(type="integer")
-     * @GeneratedValue(strategy="AUTO")
-     */
+    #[Id]
+    #[Column(type: 'integer')]
+    #[GeneratedValue(strategy: 'AUTO')]
     public int $id;
 
-    /**
-     * @Column(type="string")
-     */
+    #[Column(type: 'string')]
     public string $name;
 
     public function __construct(?string $name = null)

--- a/tests/EntityManagerAwareTestCase.php
+++ b/tests/EntityManagerAwareTestCase.php
@@ -4,14 +4,45 @@ declare(strict_types=1);
 
 namespace Bentools\DoctrineSafeEvents\Tests;
 
-use Noback\PHPUnitTestServiceContainer\PHPUnit\TestCaseWithEntityManager;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\ORMSetup;
+use Doctrine\ORM\Tools\SchemaTool;
 
 trait EntityManagerAwareTestCase
 {
-    use TestCaseWithEntityManager;
+    private EntityManagerInterface $entityManager;
+
+    public function setUpEntityManager(): void
+    {
+        $config = ORMSetup::createAttributeMetadataConfiguration(
+            paths: $this->getEntityDirectories(),
+            isDevMode: true,
+        );
+
+        $this->entityManager = EntityManager::create(
+            ['driver' => 'pdo_sqlite', 'memory' => true],
+            $config,
+        );
+
+        $schemaTool = new SchemaTool($this->entityManager);
+        $schemaTool->createSchema(
+            $this->entityManager->getMetadataFactory()->getAllMetadata()
+        );
+    }
+
+    public function tearDownEntityManager(): void
+    {
+        $this->entityManager->close();
+    }
 
     protected function getEntityDirectories(): array
     {
         return [__DIR__ . '/Entity'];
+    }
+
+    public function getEntityManager(): EntityManagerInterface
+    {
+        return $this->entityManager;
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -6,4 +6,7 @@ namespace Bentools\DoctrineSafeEvents\Tests;
 
 use function uses;
 
-uses(EntityManagerAwareTestCase::class)->in(__DIR__);
+uses(EntityManagerAwareTestCase::class)
+    ->beforeEach(fn () => $this->setUpEntityManager())
+    ->afterEach(fn () => $this->tearDownEntityManager())
+    ->in(__DIR__);


### PR DESCRIPTION
This PR fixes the CI because we had this error:

```
  Trait method Bentools\DoctrineSafeEvents\Tests\EntityManagerAwareTestCase::setUp has not been applied as P\Tests\SafeEventsDispatcherTest::setUp, because of collision with Pest\Concerns\Testable::setUp
```

So we remove the dependency of `matthiasnoback/doctrine-orm-test-service-provider` because this package has the `setUp` in collision.

Fix #9 .

We replace it by our own setup done in `beforeEach` and `afterEach` of PestPHP.

In addition, we remove the abandoned `doctrine/annotations` package and we remove the compatibility with PHP < 8.

